### PR TITLE
Suggest "Show List of Migrations" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ Usage
 2. Bring up the command pallette (CMD+SHIFT+P on Mac, CTRL+SHIFT+P on Windows).
 3. Type in "latest", and select "Rails Latest Migration: Find" from the list.
 4. And there it is, your latest migration!
+5. You can select "Rails Latest Migration: List" to open the list of all migrations.
 
 ### Via keymap
 1. Open up your Rails project *(note: for the plugin to work the project must have been opened in Atom at its root)*.
 2. Type "CTRL-CMD-L", and there it is, your latest migration!
+3. Type "SHIFT-CMD-M" to see the list of all migrations.
 
 Thanks
 --

--- a/keymaps/rails-latest-migration.cson
+++ b/keymaps/rails-latest-migration.cson
@@ -1,2 +1,3 @@
 'atom-text-editor':
   'ctrl-cmd-l': 'rails-latest-migration:find'
+  'cmd-shift-m': 'rails-latest-migration:list'

--- a/lib/migration-list-view.coffee
+++ b/lib/migration-list-view.coffee
@@ -1,0 +1,35 @@
+{ $$, SelectListView } = require 'atom-space-pen-views'
+
+module.exports =
+class MigrationListView extends SelectListView
+  initialize: (@data = []) ->
+    super
+    @show()
+    @parseData()
+
+  parseData: ->
+    migrations = @data.map (migration) ->
+      [..., name] = migration.split('/')
+
+      { name: name, file: migration }
+
+    @setItems migrations
+    @focusFilterEditor()
+
+  getFilterKey: -> 'name'
+
+  show: ->
+    @panel ?= atom.workspace.addModalPanel(item: this)
+    @panel.show()
+    @storeFocusedElement()
+
+  cancelled: -> @hide()
+
+  hide: -> @panel?.destroy()
+
+  viewForItem: ({name}) ->
+    $$ -> @li(name)
+
+  confirmed: ({file}) ->    
+    atom.workspace.open(file)
+    @cancel()

--- a/menus/rails-latest-migration.cson
+++ b/menus/rails-latest-migration.cson
@@ -4,7 +4,8 @@
     'submenu': [
       'label': 'Rails Latest Migration'
       'submenu': [
-        { 'label': 'Find Latest Migration', 'command': 'rails-latest-migration:find' }
+        { 'label': 'Find Latest Migration', 'command': 'rails-latest-migration:find' },
+        { 'label': 'Show List of Migrations', 'command': 'rails-latest-migration:list' }
       ]
     ]
   }

--- a/package.json
+++ b/package.json
@@ -4,12 +4,18 @@
   "version": "1.1.4",
   "description": "Opens the latest migration in a Rails app",
   "activationCommands": {
-    "atom-workspace": ["rails-latest-migration:find"]
+    "atom-workspace": [
+      "rails-latest-migration:find",
+      "rails-latest-migration:list"
+    ]
   },
   "repository": "https://github.com/alexpls/rails-latest-migration-atom",
   "license": "MIT",
   "engines": {
     "atom": ">0.50.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "underscore-plus": "1.x",
+    "atom-space-pen-views": "^2.1.0"
+  }
 }


### PR DESCRIPTION
This feature allows to open the pane with all the migration for easy navigation between them.

Here is how it looks:
![](https://monosnap.com/file/kD3vXSUOkbomxwBBexVbzUlqLjwI8s.png)

This feature is useful because often you don't want to open the latest migration. Instead you want to open for example a migration where you were adding foreign keys or some kind of indexies and so on.

I've used a `shift+cmd+m` shortcut for opening the pane.
